### PR TITLE
Remove hardcoded dashboard metrics

### DIFF
--- a/va_explorer/home/views.py
+++ b/va_explorer/home/views.py
@@ -24,18 +24,6 @@ class Index(CustomAuthMixin, TemplateView):
                 [location.name for location in user.location_restrictions.all()]
             )
 
-        # Add your dashboard numbers here
-        context["total_eas"] = 23890
-        context["total_people"] = 33890
-        context["total_pregnancies"] = 3400
-        context["today_pregnancies"] = 209
-        context["total_preg_outcomes"] = 5099
-        context["today_preg_outcomes"] = 692
-        context["total_deaths"] = 2348
-        context["today_deaths"] = 989
-        context["total_vas"] = 7339
-        context["today_vas"] = 808
-
         return context
 
 


### PR DESCRIPTION
## Summary
- remove hardcoded dashboard metric values from the home index view so dynamic metrics remain in the context

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d69c36581083298e04927118729e0b